### PR TITLE
Disable pushing of symbols packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,6 +69,6 @@ deploy_script:
       Write-Host "Uploading $($nugets.Count) nuget packages"
       $nugets | % { nuget.exe push $_ -Source https://www.nuget.org/api/v2/package -ApiKey $env:NUGET_API_KEY; if ($LastExitCode -ne 0) { throw; } }
 
-      $symbols = $sources | ? { $_ -like '*.symbols.nupkg' }
-      Write-Host "Uploading $($symbols.Count) symbols packages"
-      $symbols | % { nuget.exe push $_ -Source https://www.nuget.org/api/v2/package -ApiKey $env:NUGET_API_KEY; if ($LastExitCode -ne 0) { throw; } }
+#      $symbols = $sources | ? { $_ -like '*.symbols.nupkg' }
+#      Write-Host "Uploading $($symbols.Count) symbols packages"
+#      $symbols | % { nuget.exe push $_ -Source https://www.nuget.org/api/v2/package -ApiKey $env:NUGET_API_KEY; if ($LastExitCode -ne 0) { throw; } }


### PR DESCRIPTION
This seems to fail every time, and I'm kind-of hoping the NuGet push
takes care of this with some black automagic.