### PR TITLE
Lock event store per stream

### DIFF
--- a/src/RdbmsEventStore.EntityFramework.Tests/Infrastructure/EventStoreFixture.cs
+++ b/src/RdbmsEventStore.EntityFramework.Tests/Infrastructure/EventStoreFixture.cs
@@ -19,13 +19,13 @@ namespace RdbmsEventStore.EntityFramework.Tests.Infrastructure
             EventRegistry = new AssemblyEventRegistry(typeof(TEvent), type => type.Name, type => !type.Name.StartsWith("<>"));
             EventSerializer = new DefaultEventSerializer<TStreamId, TEvent, TPersistedEvent>(EventRegistry);
             EventFactory = new DefaultEventFactory<TStreamId, TEvent>();
-            WriteLock = new WriteLock();
+            WriteLock = new WriteLock<TStreamId>();
         }
 
         public IEventRegistry EventRegistry { get; protected set; }
         public IEventSerializer<TEvent, TPersistedEvent> EventSerializer { get; protected set; }
         public IEventFactory<TStreamId, TEvent> EventFactory { get; protected set; }
-        public IWriteLock WriteLock { get; protected set; }
+        public IWriteLock<TStreamId> WriteLock { get; protected set; }
 
         public EntityFrameworkEventStore<TId, TStreamId, TEventStoreContext, TEvent, TEventMetadata, TPersistedEvent> BuildEventStore<TEventStoreContext>(TEventStoreContext dbContext)
             where TEventStoreContext : DbContext, IEventDbContext<TPersistedEvent>

--- a/src/RdbmsEventStore.EntityFramework/EntityFrameworkEventStore.cs
+++ b/src/RdbmsEventStore.EntityFramework/EntityFrameworkEventStore.cs
@@ -17,10 +17,10 @@ namespace RdbmsEventStore.EntityFramework
     {
         private readonly TContext context;
         private readonly IEventFactory<TStreamId, TEvent> _eventFactory;
-        private readonly IWriteLock _writeLock;
+        private readonly IWriteLock<TStreamId> _writeLock;
         private readonly IEventSerializer<TEvent, TPersistedEvent> _serializer;
 
-        public EntityFrameworkEventStore(TContext context, IEventFactory<TStreamId, TEvent> eventFactory, IWriteLock writeLock, IEventSerializer<TEvent, TPersistedEvent> serializer)
+        public EntityFrameworkEventStore(TContext context, IEventFactory<TStreamId, TEvent> eventFactory, IWriteLock<TStreamId> writeLock, IEventSerializer<TEvent, TPersistedEvent> serializer)
         {
             this.context = context;
             _eventFactory = eventFactory;
@@ -49,7 +49,7 @@ namespace RdbmsEventStore.EntityFramework
 
         public async Task Append(TStreamId streamId, long versionBefore, IEnumerable<object> payloads)
         {
-            using (await _writeLock.Aquire())
+            using (await _writeLock.Aquire(streamId))
             {
                 var highestVersionNumber = await context.Events
                     .Where(e => e.StreamId.Equals(streamId))

--- a/src/RdbmsEventStore/IWriteLock.cs
+++ b/src/RdbmsEventStore/IWriteLock.cs
@@ -3,8 +3,8 @@ using Nito.AsyncEx;
 
 namespace RdbmsEventStore
 {
-    public interface IWriteLock
+    public interface IWriteLock<in TStreamId>
     {
-        AwaitableDisposable<IDisposable> Aquire();
+        AwaitableDisposable<IDisposable> Aquire(TStreamId streamId);
     }
 }

--- a/src/RdbmsEventStore/WriteLock.cs
+++ b/src/RdbmsEventStore/WriteLock.cs
@@ -1,12 +1,13 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using Nito.AsyncEx;
 
 namespace RdbmsEventStore
 {
-    public class WriteLock : IWriteLock
+    public class WriteLock<TStreamId> : IWriteLock<TStreamId>
     {
-        private readonly AsyncLock _mutex = new AsyncLock();
+        private readonly ConcurrentDictionary<TStreamId, AsyncLock> _mutexes = new ConcurrentDictionary<TStreamId, AsyncLock>();
 
-        public AwaitableDisposable<IDisposable> Aquire() => _mutex.LockAsync();
+        public AwaitableDisposable<IDisposable> Aquire(TStreamId streamId) => _mutexes.GetOrAdd(streamId, id => new AsyncLock()).LockAsync();
     }
 }


### PR DESCRIPTION
This enables much better concurrency scenarios; instead of disallowing *all* concurrent writes to the event store, we now only disallow concurrent writes to *a single event stream*. This enables e.g. different users to update different data sets without having to wait for each-other.

Fixes #25.