### PR TITLE
Query all events

### DIFF
--- a/src/RdbmsEventStore.EntityFramework.Tests/EventStoreTests/QueryEventsTests.cs
+++ b/src/RdbmsEventStore.EntityFramework.Tests/EventStoreTests/QueryEventsTests.cs
@@ -46,5 +46,21 @@ namespace RdbmsEventStore.EntityFramework.Tests.EventStoreTests
             var events = await store.Events(streamId, es => es.Where(e => e.Version > 1));
             Assert.Equal(expectedCount, events.Count());
         }
+
+        [Fact]
+        public async Task ReturnsAllEvents()
+        {
+            var store = _fixture.BuildEventStore(_dbContext) as IEventStream<string, StringEvent, IEventMetadata<string>>;
+            var events = await store.Events();
+            Assert.Equal(5, events.Count());
+        }
+
+        [Fact]
+        public async Task ReturnsAllEventsAccordingToQuery()
+        {
+            var store = _fixture.BuildEventStore(_dbContext) as IEventStream<string, StringEvent, IEventMetadata<string>>;
+            var events = await store.Events(es => es.Where(e => e.Version > 1));
+            Assert.Equal(3, events.Count());
+        }
     }
 }

--- a/src/RdbmsEventStore.EntityFramework/EntityFrameworkEventStore.cs
+++ b/src/RdbmsEventStore.EntityFramework/EntityFrameworkEventStore.cs
@@ -28,7 +28,7 @@ namespace RdbmsEventStore.EntityFramework
             _serializer = serializer;
         }
 
-        public  Task<IEnumerable<TEvent>> Events() => Events(query => query);
+        public  Task<IEnumerable<TEvent>> Events() => Events(events => events);
 
         public async Task<IEnumerable<TEvent>> Events(Func<IQueryable<TEventMetadata>, IQueryable<TEventMetadata>> query)
         {
@@ -44,7 +44,7 @@ namespace RdbmsEventStore.EntityFramework
             return events;
         }
 
-        public Task<IEnumerable<TEvent>> Events(TStreamId streamId) => Events(streamId, query => query);
+        public Task<IEnumerable<TEvent>> Events(TStreamId streamId) => Events(streamId, events => events);
 
         public async Task<IEnumerable<TEvent>> Events(TStreamId streamId, Func<IQueryable<TEventMetadata>, IQueryable<TEventMetadata>> query)
         {

--- a/src/RdbmsEventStore/IEventStream.cs
+++ b/src/RdbmsEventStore/IEventStream.cs
@@ -9,6 +9,10 @@ namespace RdbmsEventStore
         where TEvent : IEvent<TStreamId>, TEventMetadata
         where TEventMetadata : IEventMetadata<TStreamId>
     {
+        Task<IEnumerable<TEvent>> Events();
+
+        Task<IEnumerable<TEvent>> Events(Func<IQueryable<TEventMetadata>, IQueryable<TEventMetadata>> query);
+
         Task<IEnumerable<TEvent>> Events(TStreamId streamId);
 
         Task<IEnumerable<TEvent>> Events(TStreamId streamId, Func<IQueryable<TEventMetadata>, IQueryable<TEventMetadata>> query);


### PR DESCRIPTION
This enables querying events from across multiple streams, and not just one stream at a time.