### PR TITLE
Don't expose the version number

### DIFF
--- a/src/RdbmsEventStore.EFCore.Tests/EventStoreTests/ExtraMetaTests.cs
+++ b/src/RdbmsEventStore.EFCore.Tests/EventStoreTests/ExtraMetaTests.cs
@@ -23,13 +23,13 @@ namespace RdbmsEventStore.EFCore.Tests.EventStoreTests
                 .Options;
             _dbContext = new EFCoreEventStoreContext<string, ExtraMetaLongStringPersistedEventMetadata>(options);
 
-            var stream1 = _fixture.EventFactory.Create("stream-1", 0, new object[] {
+            var stream1 = _fixture.EventFactory.Create("stream-1", new object[] {
                     new FooEvent { Foo = "Foo" },
                     new BarEvent { Bar = "Bar" },
                     new FooEvent { Foo = "Baz" }
                 })
                 .Select(_fixture.EventSerializer.Serialize);
-            var stream2 = _fixture.EventFactory.Create("stream-2", 0, new object[] {
+            var stream2 = _fixture.EventFactory.Create("stream-2", new object[] {
                     new FooEvent { Foo = "Boo" },
                     new BarEvent { Bar = "Far" }
                 })
@@ -89,9 +89,9 @@ namespace RdbmsEventStore.EFCore.Tests.EventStoreTests
     {
         private int _total;
 
-        protected override ExtraMetaStringEvent CreateSingle(string streamId, long version, object payload)
+        protected override ExtraMetaStringEvent CreateSingle(string streamId, object payload)
         {
-            var @event = base.CreateSingle(streamId, version, payload);
+            var @event = base.CreateSingle(streamId, payload);
             @event.ExtraMeta = $"{payload.GetType().Name}-{_total++}";
             return @event;
         }

--- a/src/RdbmsEventStore.EFCore.Tests/EventStoreTests/QueryEventsTests.cs
+++ b/src/RdbmsEventStore.EFCore.Tests/EventStoreTests/QueryEventsTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using RdbmsEventStore.EFCore.Tests.Infrastructure;
 using RdbmsEventStore.EFCore.Tests.TestData;
 using Xunit;
@@ -10,21 +12,22 @@ namespace RdbmsEventStore.EFCore.Tests.EventStoreTests
     {
         public QueryEventsTests(EventStoreFixture<long, string, StringEvent, IEventMetadata<string>, LongStringPersistedEvent> fixture) : base(fixture)
         {
-            var stream1 = _fixture.EventFactory.Create("stream-1", 0, new object[] {
-                    new FooEvent { Foo = "Foo" },
-                    new BarEvent { Bar = "Bar" },
-                    new FooEvent { Foo = "Baz" }
-                })
-                .Select(_fixture.EventSerializer.Serialize);
-            var stream2 = _fixture.EventFactory.Create("stream-2", 0, new object[] {
-                    new FooEvent { Foo = "Boo" },
-                    new BarEvent { Bar = "Far" }
-                })
-                .Select(_fixture.EventSerializer.Serialize);
+            AddEvents("stream-1", new FooEvent { Foo = "Foo" });
+            Thread.Sleep(10); // to make timestamps differ between the first and the rest
+            AddEvents("stream-1", new BarEvent { Bar = "Bar" }, new FooEvent { Foo = "Baz" });
+            AddEvents("stream-2", new FooEvent { Foo = "Boo" });
+            Thread.Sleep(10);
+            AddEvents("stream-2", new BarEvent { Bar = "Far" });
 
-            _dbContext.Events.AddRange(stream1);
-            _dbContext.Events.AddRange(stream2);
             _dbContext.SaveChanges();
+        }
+
+        private void AddEvents(string streamId, params object[] payloads)
+        {
+            var events = _fixture.EventFactory.Create(streamId, payloads)
+                .Select(_fixture.EventSerializer.Serialize)
+                .VersionedPerTimestamp<LongStringPersistedEvent, string>();
+            _dbContext.Events.AddRange(events);
         }
 
         [Theory]
@@ -42,8 +45,13 @@ namespace RdbmsEventStore.EFCore.Tests.EventStoreTests
         [InlineData("stream-2", 1)]
         public async Task ReturnsEventsAccordingToQuery(string streamId, long expectedCount)
         {
+            var firstEventTimestamp = await _dbContext.Events
+                .Where(e => e.StreamId == streamId)
+                .Select(e => e.Timestamp)
+                .FirstAsync();
+
             var store = _fixture.BuildEventStore(_dbContext) as IEventStore<string, StringEvent, IEventMetadata<string>>;
-            var events = await store.Events(streamId, es => es.Where(e => e.Version > 1));
+            var events = await store.Events(streamId, es => es.Where(e => e.Timestamp > firstEventTimestamp));
             Assert.Equal(expectedCount, events.Count());
         }
 
@@ -58,9 +66,13 @@ namespace RdbmsEventStore.EFCore.Tests.EventStoreTests
         [Fact]
         public async Task ReturnsAllEventsAccordingToQuery()
         {
+            var firstEventTimestamp = await _dbContext.Events
+                .Select(e => e.Timestamp)
+                .FirstAsync();
+
             var store = _fixture.BuildEventStore(_dbContext) as IEventStore<string, StringEvent, IEventMetadata<string>>;
-            var events = await store.Events(es => es.Where(e => e.Version > 1));
-            Assert.Equal(3, events.Count());
+            var events = await store.Events(es => es.Where(e => e.Timestamp > firstEventTimestamp));
+            Assert.Equal(4, events.Count());
         }
     }
 }

--- a/src/RdbmsEventStore.EFCore.Tests/EventStoreTests/WriteEventTests.cs
+++ b/src/RdbmsEventStore.EFCore.Tests/EventStoreTests/WriteEventTests.cs
@@ -19,7 +19,7 @@ namespace RdbmsEventStore.EFCore.Tests.EventStoreTests
         public async Task CommittingEventStoresEventInContext()
         {
             var store = _fixture.BuildEventStore(_dbContext);
-            await store.Append(Guid.NewGuid(), 0, new[] { new FooEvent { Foo = "Bar" } });
+            await store.Append(Guid.NewGuid(), null, new[] { new FooEvent { Foo = "Bar" } });
             Assert.Equal(1, await _dbContext.Events.CountAsync());
         }
 
@@ -28,10 +28,10 @@ namespace RdbmsEventStore.EFCore.Tests.EventStoreTests
         {
             var store = _fixture.BuildEventStore(_dbContext);
             var stream = Guid.NewGuid();
-            _dbContext.Events.AddRange(_fixture.EventFactory.Create(stream, 0, new[] { new FooEvent { Foo = "Bar" } }).Select(_fixture.EventSerializer.Serialize));
+            _dbContext.Events.AddRange(_fixture.EventFactory.Create(stream, new[] { new FooEvent { Foo = "Bar" } }).Select(_fixture.EventSerializer.Serialize));
             await _dbContext.SaveChangesAsync();
 
-            await Assert.ThrowsAsync<ConflictException>(() => store.Append(stream, 0, new[] { new FooEvent { Foo = "Qux" } }));
+            await Assert.ThrowsAsync<ConflictException>(() => store.Append(stream, null, new[] { new FooEvent { Foo = "Qux" } }));
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace RdbmsEventStore.EFCore.Tests.EventStoreTests
             var store = _fixture.BuildEventStore(context.Object);
 
             try {
-                await store.Append(stream, 0, new object[] { });
+                await store.Append(stream, null, new object[] { });
             } catch (NotImplementedException) {
                 // Thrown by the mock DbSet if we try to query for existing events
                 // This indicates that we didn't exit early
@@ -61,7 +61,7 @@ namespace RdbmsEventStore.EFCore.Tests.EventStoreTests
             var store = _fixture.BuildEventStore(_dbContext);
 
             var events = new[] { new FooEvent { Foo = "Foo" }, new FooEvent { Foo = "Bar" } };
-            await store.Append(Guid.NewGuid(), 0, events);
+            await store.Append(Guid.NewGuid(), null, events);
 
             Assert.Equal(2, await _dbContext.Events.CountAsync());
         }
@@ -74,7 +74,7 @@ namespace RdbmsEventStore.EFCore.Tests.EventStoreTests
             var store = _fixture.BuildEventStore(_dbContext);
 
             var events = new object[] { new FooEvent { Foo = "Foo" }, new BarEvent { Bar = "Bar" } };
-            await store.Append(Guid.NewGuid(), 0, events);
+            await store.Append(Guid.NewGuid(), null, events);
 
             Assert.Collection(await _dbContext.Events.OrderBy(e => e.Version).ToListAsync(),
                 foo => Assert.Equal(typeof(FooEvent), _fixture.EventRegistry.TypeFor(foo.Type)),
@@ -88,12 +88,11 @@ namespace RdbmsEventStore.EFCore.Tests.EventStoreTests
 
             var store = _fixture.BuildEventStore(_dbContext);
             var events = new object[] { new FooEvent { Foo = "Foo" }, new BarEvent { Bar = "Bar" } };
-            await store.Append(Guid.NewGuid(), 0, events);
+            await store.Append(Guid.NewGuid(), null, events);
 
-            var storedEvents = await _dbContext.Events.OrderBy(e => e.Timestamp).ToListAsync();
-            Assert.Collection(storedEvents,
-                foo => Assert.Equal(1, foo.Version),
-                bar => Assert.Equal(2, bar.Version));
+            Assert.Collection(await _dbContext.Events.OrderBy(e => e.Timestamp).ToListAsync(),
+                foo => Assert.Equal(typeof(FooEvent), _fixture.EventRegistry.TypeFor(foo.Type)),
+                bar => Assert.Equal(typeof(BarEvent), _fixture.EventRegistry.TypeFor(bar.Type)));
         }
     }
 }

--- a/src/RdbmsEventStore.EFCore.Tests/ExtensibilityTests/NonDefaultImplementationsTests.cs
+++ b/src/RdbmsEventStore.EFCore.Tests/ExtensibilityTests/NonDefaultImplementationsTests.cs
@@ -66,7 +66,7 @@ namespace RdbmsEventStore.EFCore.Tests.ExtensibilityTests
         {
             var store = _fixture.BuildEventStore(_dbContext);
 
-            await store.Append(1, 0, new[] { new FooEvent { Foo = "Bar" } });
+            await store.Append(1, null, new[] { new FooEvent { Foo = "Bar" } });
         }
 
         [Fact]

--- a/src/RdbmsEventStore.EntityFramework.Tests/EventStoreTests/ExtraMetaTests.cs
+++ b/src/RdbmsEventStore.EntityFramework.Tests/EventStoreTests/ExtraMetaTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using RdbmsEventStore.EntityFramework.Tests.Infrastructure;
 using RdbmsEventStore.EntityFramework.Tests.TestData;
@@ -21,13 +22,13 @@ namespace RdbmsEventStore.EntityFramework.Tests.EventStoreTests
             _fixture = fixture;
             _dbContext = new EntityFrameworkEventStoreContext<ExtraMetaLongStringPersistedEventMetadata>();
 
-            var stream1 = _fixture.EventFactory.Create("stream-1", 0, new object[] {
+            var stream1 = _fixture.EventFactory.Create("stream-1", new object[] {
                     new FooEvent { Foo = "Foo" },
                     new BarEvent { Bar = "Bar" },
                     new FooEvent { Foo = "Baz" }
                 })
                 .Select(_fixture.EventSerializer.Serialize);
-            var stream2 = _fixture.EventFactory.Create("stream-2", 0, new object[] {
+            var stream2 = _fixture.EventFactory.Create("stream-2", new object[] {
                     new FooEvent { Foo = "Boo" },
                     new BarEvent { Bar = "Far" }
                 })
@@ -87,9 +88,9 @@ namespace RdbmsEventStore.EntityFramework.Tests.EventStoreTests
     {
         private int _total;
 
-        protected override ExtraMetaStringEvent CreateSingle(string streamId, long version, object payload)
+        protected override ExtraMetaStringEvent CreateSingle(string streamId, object payload)
         {
-            var @event = base.CreateSingle(streamId, version, payload);
+            var @event = base.CreateSingle(streamId, payload);
             @event.ExtraMeta = $"{payload.GetType().Name}-{_total++}";
             return @event;
         }

--- a/src/RdbmsEventStore.EntityFramework.Tests/EventStoreTests/WriteEventTests.cs
+++ b/src/RdbmsEventStore.EntityFramework.Tests/EventStoreTests/WriteEventTests.cs
@@ -20,7 +20,7 @@ namespace RdbmsEventStore.EntityFramework.Tests.EventStoreTests
         public async Task CommittingEventStoresEventInContext()
         {
             var store = _fixture.BuildEventStore(_dbContext);
-            await store.Append(Guid.NewGuid(), 0, new[] { new FooEvent { Foo = "Bar" } });
+            await store.Append(Guid.NewGuid(), null, new[] { new FooEvent { Foo = "Bar" } });
             Assert.Equal(1, await _dbContext.Events.CountAsync());
         }
 
@@ -29,10 +29,10 @@ namespace RdbmsEventStore.EntityFramework.Tests.EventStoreTests
         {
             var store = _fixture.BuildEventStore(_dbContext);
             var stream = Guid.NewGuid();
-            _dbContext.Events.AddRange(_fixture.EventFactory.Create(stream, 0, new[] { new FooEvent { Foo = "Bar" } }).Select(_fixture.EventSerializer.Serialize));
+            _dbContext.Events.AddRange(_fixture.EventFactory.Create(stream, new[] { new FooEvent { Foo = "Bar" } }).Select(_fixture.EventSerializer.Serialize));
             await _dbContext.SaveChangesAsync();
 
-            await Assert.ThrowsAsync<ConflictException>(() => store.Append(stream, 0, new[] { new FooEvent { Foo = "Qux" } }));
+            await Assert.ThrowsAsync<ConflictException>(() => store.Append(stream, null, new[] { new FooEvent { Foo = "Qux" } }));
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace RdbmsEventStore.EntityFramework.Tests.EventStoreTests
             var store = _fixture.BuildEventStore(context.Object);
 
             try {
-                await store.Append(stream, 0, new object[] { });
+                await store.Append(stream, null, new object[] { });
             } catch (NotImplementedException) {
                 // Thrown by the mock DbSet if we try to query for existing events
                 // This indicates that we didn't exit early
@@ -62,7 +62,7 @@ namespace RdbmsEventStore.EntityFramework.Tests.EventStoreTests
             var store = _fixture.BuildEventStore(_dbContext);
 
             var events = new[] { new FooEvent { Foo = "Foo" }, new FooEvent { Foo = "Bar" } };
-            await store.Append(Guid.NewGuid(), 0, events);
+            await store.Append(Guid.NewGuid(), null, events);
 
             Assert.Equal(2, await _dbContext.Events.CountAsync());
         }
@@ -75,26 +75,11 @@ namespace RdbmsEventStore.EntityFramework.Tests.EventStoreTests
             var store = _fixture.BuildEventStore(_dbContext);
 
             var events = new object[] { new FooEvent { Foo = "Foo" }, new BarEvent { Bar = "Bar" } };
-            await store.Append(Guid.NewGuid(), 0, events);
+            await store.Append(Guid.NewGuid(), null, events);
 
-            Assert.Collection(await _dbContext.Events.OrderBy(e => e.Version).ToListAsync(),
+            Assert.Collection(await _dbContext.Events.OrderBy(e => e.Timestamp).ToListAsync(),
                 foo => Assert.Equal(typeof(FooEvent), _fixture.EventRegistry.TypeFor(foo.Type)),
                 bar => Assert.Equal(typeof(BarEvent), _fixture.EventRegistry.TypeFor(bar.Type)));
-        }
-
-        [Fact]
-        public async Task CommittingMultipleEventsIncrementsVersionForEachEvent()
-        {
-            Assert.Empty(await _dbContext.Events.ToListAsync());
-
-            var store = _fixture.BuildEventStore(_dbContext);
-            var events = new object[] { new FooEvent { Foo = "Foo" }, new BarEvent { Bar = "Bar" } };
-            await store.Append(Guid.NewGuid(), 0, events);
-
-            var storedEvents = await _dbContext.Events.OrderBy(e => e.Timestamp).ToListAsync();
-            Assert.Collection(storedEvents,
-                foo => Assert.Equal(1, foo.Version),
-                bar => Assert.Equal(2, bar.Version));
         }
     }
 }

--- a/src/RdbmsEventStore.EntityFramework.Tests/ExtensibilityTests/NonDefaultImplementationsTests.cs
+++ b/src/RdbmsEventStore.EntityFramework.Tests/ExtensibilityTests/NonDefaultImplementationsTests.cs
@@ -15,7 +15,6 @@ namespace RdbmsEventStore.EntityFramework.Tests.ExtensibilityTests
     {
         public DateTimeOffset Timestamp { get; set; }
         public long StreamId { get; set; }
-        public long Version { get; set; }
         public Type Type { get; set; }
         public object Payload { get; set; }
     }
@@ -60,7 +59,7 @@ namespace RdbmsEventStore.EntityFramework.Tests.ExtensibilityTests
         {
             var store = _fixture.BuildEventStore(_dbContext);
 
-            await store.Append(1, 0, new[] { new FooEvent { Foo = "Bar" } });
+            await store.Append(1, null, new[] { new FooEvent { Foo = "Bar" } });
         }
 
         [Fact]

--- a/src/RdbmsEventStore.Tests/EventCollectionTests.cs
+++ b/src/RdbmsEventStore.Tests/EventCollectionTests.cs
@@ -10,16 +10,14 @@ namespace RdbmsEventStore.Tests
         {
             public DateTimeOffset Timestamp { get; set; }
             public Guid StreamId { get; set; }
-            public long Version { get; set; }
             public Type Type { get; set; }
             public object Payload { get; set; }
         }
 
-        private static TestEvent Factory(Guid stream, long version, object payload)
+        private static TestEvent Factory(Guid stream, object payload)
             => new TestEvent
             {
                 StreamId = stream,
-                Version = version,
                 Timestamp = DateTimeOffset.Now,
                 Type = payload.GetType(),
                 Payload = payload
@@ -30,21 +28,13 @@ namespace RdbmsEventStore.Tests
         public EventCollectionTests()
         {
             var streamId = Guid.NewGuid();
-            _collection = new EventCollection<Guid, TestEvent>(streamId, 0, Factory, new object[] { new { Foo = "Foo" }, new { Bar = "Bar" } });
+            _collection = new EventCollection<Guid, TestEvent>(streamId, Factory, new object[] { new { Foo = "Foo" }, new { Bar = "Bar" } });
         }
 
         [Fact]
         public void EventCollectionContainsCorrectNumberOfElements()
         {
             Assert.Equal(2, _collection.Count());
-        }
-
-        [Fact]
-        public void EventCollectionCorrectlyVersionsEvents()
-        {
-            Assert.Collection(_collection.Select(e => e.Version),
-                v => Assert.Equal(1, v),
-                v => Assert.Equal(2, v));
         }
     }
 }

--- a/src/RdbmsEventStore/ConflictException.cs
+++ b/src/RdbmsEventStore/ConflictException.cs
@@ -5,10 +5,10 @@ namespace RdbmsEventStore
 {
     public class ConflictException : InvalidOperationException
     {
-        public ConflictException(object streamId, long aggregateVersionBefore, long currentVersion, params object[] payloads)
+        public ConflictException(object streamId, DateTimeOffset? aggregateVersionBefore, DateTimeOffset? currentVersion, params object[] payloads)
             : base(@"Event store conflict: You are trying to commit events which are based on an outdated view of the state. " + 
                   "Re-load the state, re-apply your actions based on the up-to-date information, and try again.\n" +
-                   $"Event stream: {streamId}\nVersion in memory: {aggregateVersionBefore}\nVersion in database: {currentVersion}\n" +
+                   $"Event stream: {streamId}\nVersion in memory: {aggregateVersionBefore?.ToString() ?? "<initial>"}\nVersion in database: {currentVersion?.ToString() ?? "<initial>"}\n" +
                   $"Events: {string.Join(", ", payloads.Select(p => p.GetType().Name))}")
         {
         }

--- a/src/RdbmsEventStore/Event.cs
+++ b/src/RdbmsEventStore/Event.cs
@@ -6,7 +6,6 @@ namespace RdbmsEventStore
     {
         public DateTimeOffset Timestamp { get; set; }
         public TStreamId StreamId { get; set; }
-        public long Version { get; set; }
         public Type Type { get; set; }
         public object Payload { get; set; }
     }

--- a/src/RdbmsEventStore/EventCollection.cs
+++ b/src/RdbmsEventStore/EventCollection.cs
@@ -9,9 +9,9 @@ namespace RdbmsEventStore
     {
         private readonly IEnumerable<TEvent> _events;
 
-        public EventCollection(TStreamId streamId, long currentVersion, Func<TStreamId, long, object, TEvent> factory, IEnumerable<object> payloads)
+        public EventCollection(TStreamId streamId, Func<TStreamId, object, TEvent> factory, IEnumerable<object> payloads)
         {
-            _events = payloads.Select((payload, i) => factory(streamId, currentVersion + 1 + i, payload));
+            _events = payloads.Select(payload => factory(streamId, payload));
         }
 
         public IEnumerator<TEvent> GetEnumerator() => _events.GetEnumerator();

--- a/src/RdbmsEventStore/EventEnumerableExtensions.cs
+++ b/src/RdbmsEventStore/EventEnumerableExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using RdbmsEventStore.Serialization;
+
+namespace RdbmsEventStore
+{
+    public static class EventEnumerableExtensions
+    {
+        public static IEnumerable<TPersistedEvent> VersionedPerTimestamp<TPersistedEvent, TStreamId>(this IEnumerable<TPersistedEvent> source)
+            where TPersistedEvent : IPersistedEvent<TStreamId>
+            => source.GroupBy(@event => @event.Timestamp)
+                .OrderBy(group => group.Key)
+                .Select(group => group.Select((@event, i) =>
+                {
+                    @event.Version = i;
+                    return @event;
+                }))
+                .SelectMany(group => group);
+    }
+}

--- a/src/RdbmsEventStore/EventStoreExtensions.cs
+++ b/src/RdbmsEventStore/EventStoreExtensions.cs
@@ -25,7 +25,7 @@ namespace RdbmsEventStore
             where TEventMetadata : class, IEventMetadata<TStreamId>
             => store.Events(events => events.Where(e => e.StreamId.Equals(streamId)).Apply(query));
 
-        public static Task Append<TStreamId, TEvent, TEventMetadata>(this IEventStore<TStreamId, TEvent, TEventMetadata> store, TStreamId streamId, long versionBefore, object payload)
+        public static Task Append<TStreamId, TEvent, TEventMetadata>(this IEventStore<TStreamId, TEvent, TEventMetadata> store, TStreamId streamId, DateTimeOffset versionBefore, object payload)
             where TStreamId : IEquatable<TStreamId>
             where TEvent : class, TEventMetadata, IEvent<TStreamId>
             where TEventMetadata : class, IEventMetadata<TStreamId>

--- a/src/RdbmsEventStore/IEventMetadata.cs
+++ b/src/RdbmsEventStore/IEventMetadata.cs
@@ -7,7 +7,5 @@ namespace RdbmsEventStore
         DateTimeOffset Timestamp { get; }
 
         TStreamId StreamId { get; }
-
-        long Version { get; }
     }
 }

--- a/src/RdbmsEventStore/IEventStore.cs
+++ b/src/RdbmsEventStore/IEventStore.cs
@@ -12,6 +12,6 @@ namespace RdbmsEventStore
     {
         Task<IEnumerable<TEvent>> Events(Func<IQueryable<TEventMetadata>, IQueryable<TEventMetadata>> query);
 
-        Task Append(TStreamId streamId, long versionBefore, IEnumerable<object> payloads);
+        Task Append(TStreamId streamId, DateTimeOffset? versionBefore, IEnumerable<object> payloads);
     }
 }

--- a/src/RdbmsEventStore/IMutableEventMetadata.cs
+++ b/src/RdbmsEventStore/IMutableEventMetadata.cs
@@ -7,7 +7,5 @@ namespace RdbmsEventStore
         new DateTimeOffset Timestamp { get; set; }
 
         new TStreamId StreamId { get; set; }
-
-        new long Version { get; set; }
     }
 }

--- a/src/RdbmsEventStore/Serialization/DefaultEventFactory.cs
+++ b/src/RdbmsEventStore/Serialization/DefaultEventFactory.cs
@@ -5,18 +5,17 @@ namespace RdbmsEventStore.Serialization
 {
     public class DefaultEventFactory<TStreamId, TEvent> : IEventFactory<TStreamId, TEvent> where TEvent : IMutableEvent<TStreamId>, new()
     {
-        public virtual IEnumerable<TEvent> Create(TStreamId streamId, long version, IEnumerable<object> payloads)
+        public virtual IEnumerable<TEvent> Create(TStreamId streamId, IEnumerable<object> payloads)
         {
-            return new EventCollection<TStreamId, TEvent>(streamId, version, CreateSingle, payloads);
+            return new EventCollection<TStreamId, TEvent>(streamId, CreateSingle, payloads);
         }
 
-        protected virtual TEvent CreateSingle(TStreamId streamId, long version, object payload)
+        protected virtual TEvent CreateSingle(TStreamId streamId, object payload)
         {
             return new TEvent
             {
                 StreamId = streamId,
                 Timestamp = DateTimeOffset.UtcNow,
-                Version = version,
                 Type = payload.GetType(),
                 Payload = payload
             };

--- a/src/RdbmsEventStore/Serialization/DefaultEventSerializer.cs
+++ b/src/RdbmsEventStore/Serialization/DefaultEventSerializer.cs
@@ -25,7 +25,6 @@ namespace RdbmsEventStore.Serialization
             {
                 StreamId = @event.StreamId,
                 Timestamp = @event.Timestamp,
-                Version = @event.Version,
                 Type = type,
                 Payload = payload
             };
@@ -41,7 +40,6 @@ namespace RdbmsEventStore.Serialization
             {
                 StreamId = @event.StreamId,
                 Timestamp = @event.Timestamp,
-                Version = @event.Version,
                 Type = type,
                 Payload = payload
             };

--- a/src/RdbmsEventStore/Serialization/IEventFactory.cs
+++ b/src/RdbmsEventStore/Serialization/IEventFactory.cs
@@ -4,6 +4,6 @@ namespace RdbmsEventStore.Serialization
 {
     public interface IEventFactory<in TStreamId, out TEvent> where TEvent : IEvent<TStreamId>
     {
-        IEnumerable<TEvent> Create(TStreamId streamId, long version, IEnumerable<object> payloads);
+        IEnumerable<TEvent> Create(TStreamId streamId, IEnumerable<object> payloads);
     }
 }

--- a/src/RdbmsEventStore/Serialization/IPersistedEvent.cs
+++ b/src/RdbmsEventStore/Serialization/IPersistedEvent.cs
@@ -2,6 +2,8 @@
 {
     public interface IPersistedEvent<TStreamId> : IMutableEventMetadata<TStreamId>
     {
+        long Version { get; set; }
+
         string Type { get; set; }
 
         byte[] Payload { get; set; }


### PR DESCRIPTION
Exposing the version number is problematic, since if we want to change
history by deleting or adding events in the past, we have to re-version
every single event that comes later in the stream.

Instead, we now use timestamps for versioning.

However, neither EF nor EF Core guarantees the ordering of entities that
are inserted in the same batch, which means we need a way to version
events that are inserted togehter to ensure that they are retreived in
the same order they were created. Therefore, we keep the Version property
on the persisted event types, but use it only internally inside the EF
providers.

The version number is also now grouped per timestamp, so that for each new
timestamp the version number restarts.